### PR TITLE
Fix parameter retrieval logic

### DIFF
--- a/lib/tools.ts
+++ b/lib/tools.ts
@@ -694,8 +694,8 @@ function getValueOfParameter(
     parameterName: string,
     parameters: FunctionParameter[],
 ) {
-    return parameters.filter((p) => p.parameterName === parameterName)[0]
-        .parameterValue;
+    const param = parameters.find((p) => p.parameterName === parameterName)
+    return param ? param.parameterValue : undefined
 }
 
 export async function executeFunction(


### PR DESCRIPTION
## Summary
- handle missing parameters in `getValueOfParameter`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1b52c738832b9fae67332f3c1d54