### PR TITLE
Fix comment typography message

### DIFF
--- a/components/signin.tsx
+++ b/components/signin.tsx
@@ -13,7 +13,7 @@ inter({
   display: 'swap',
 })
 
-To read more about using these font, please visit the Next.js documentation:
+To read more about using these fonts, please visit the Next.js documentation:
 - App Directory: https://nextjs.org/docs/app/building-your-application/optimizing/fonts
 - Pages Directory: https://nextjs.org/docs/pages/building-your-application/optimizing/fonts
 **/

--- a/components/signup.tsx
+++ b/components/signup.tsx
@@ -13,7 +13,7 @@ inter({
   display: 'swap',
 })
 
-To read more about using these font, please visit the Next.js documentation:
+To read more about using these fonts, please visit the Next.js documentation:
 - App Directory: https://nextjs.org/docs/app/building-your-application/optimizing/fonts
 - Pages Directory: https://nextjs.org/docs/pages/building-your-application/optimizing/fonts
 **/


### PR DESCRIPTION
## Summary
- correct small typo in signup and signin font usage comments

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1ed610dc832ba29c326f39bc2319