### PR TITLE
Fix end time calculation

### DIFF
--- a/app/api/activities/strava/route.ts
+++ b/app/api/activities/strava/route.ts
@@ -118,7 +118,7 @@ export async function GET(request: NextRequest) {
                 }
 
                 const startTime = new Date(activity.start_date);
-                const endTime = new Date(activity.start_date_local);
+                const endTime = new Date(startTime.getTime() + activity.elapsed_time * 1000);
 
                 // Create or update activity in our database
                 const existingActivity = await prisma.activity.findFirst({


### PR DESCRIPTION
## Summary
- correct the end time calculation in Strava import

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c1eca09e0832b86fcf0df38fed8a4